### PR TITLE
Remove tag_filter for matching release assets

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -21,7 +21,6 @@ dependencies:
   uses:         docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
     owner:      sap
-    glob:       java-memory-assistant-+..jar
+    glob:       java-memory-assistant-(.+).jar
     repository: java-memory-assistant
-    tag_filter: '[\d]+\.[\d]+\.[\d]+'
     token:      ${{ secrets.JAVA_GITHUB_TOKEN }}

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -18,7 +18,7 @@ jobs:
                 username: _json_key
             - uses: actions/setup-go@v2
               with:
-                go-version: "1.16"
+                go-version: "1.17"
             - name: Install create-package
               run: |
                 #!/usr/bin/env bash
@@ -44,7 +44,7 @@ jobs:
                   "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
                 | tar -C "${HOME}/bin" -xz crane
               env:
-                CRANE_VERSION: 0.6.0
+                CRANE_VERSION: 0.8.0
             - name: Install pack
               run: |
                 #!/usr/bin/env bash
@@ -63,7 +63,7 @@ jobs:
                   "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
                 | tar -C "${HOME}"/bin -xz pack
               env:
-                PACK_VERSION: 0.21.1
+                PACK_VERSION: 0.23.0
             - name: Enable pack Experimental
               if: ${{ false }}
               run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v2
               with:
-                go-version: "1.16"
+                go-version: "1.17"
             - name: Install create-package
               run: |
                 #!/usr/bin/env bash
@@ -38,7 +38,7 @@ jobs:
                   "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
                 | tar -C "${HOME}"/bin -xz pack
               env:
-                PACK_VERSION: 0.21.1
+                PACK_VERSION: 0.23.0
             - name: Enable pack Experimental
               if: ${{ false }}
               run: |
@@ -152,7 +152,7 @@ jobs:
                 restore-keys: ${{ runner.os }}-go-
             - uses: actions/setup-go@v2
               with:
-                go-version: "1.16"
+                go-version: "1.17"
             - name: Install richgo
               run: |
                 #!/usr/bin/env bash
@@ -171,7 +171,7 @@ jobs:
                   "https://github.com/kyoh86/richgo/releases/download/v${RICHGO_VERSION}/richgo_${RICHGO_VERSION}_linux_amd64.tar.gz" \
                 | tar -C "${HOME}"/bin -xz richgo
               env:
-                RICHGO_VERSION: 0.3.9
+                RICHGO_VERSION: 0.3.10
             - name: Run Tests
               run: |
                 #!/usr/bin/env bash

--- a/.github/workflows/update-java-memory-assistant.yml
+++ b/.github/workflows/update-java-memory-assistant.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v2
               with:
-                go-version: "1.16"
+                go-version: "1.17"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -47,7 +47,6 @@ jobs:
                 glob: java-memory-assistant-+..jar
                 owner: sap
                 repository: java-memory-assistant
-                tag_filter: '[\d]+\.[\d]+\.[\d]+'
                 token: ${{ secrets.JAVA_GITHUB_TOKEN }}
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/update-pipeline.yml
+++ b/.github/workflows/update-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v2
               with:
-                go-version: "1.16"
+                go-version: "1.17"
             - name: Install octo
               run: |
                 #!/usr/bin/env bash


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Default tag_filter works to match github tags, removing the parameter that is currently passed to update-dependency action
Also bumps CI tool version as a test

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
