### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/java-memory-assistant`
 
-The Paketo Java Memory Assistant Buildpack is a Cloud Native Buildpack that configures the SAP Java Memory Assistant (JMA) Agent for Java applications.
+The Paketo Buildpack for Java Memory Assistant is a Cloud Native Buildpack that configures the SAP Java Memory Assistant (JMA) Agent for Java applications.
 
 ## Behavior
 This buildpack will participate if all the following conditions are met

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/java-memory-assistant"
   id = "paketo-buildpacks/java-memory-assistant"
   keywords = ["agent"]
-  name = "Paketo Java Memory Assistant Buildpack"
+  name = "Paketo Buildpack for Java Memory Assistant"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Java Memory Assistant Buildpack' to 'Paketo Buildpack for Java Memory Assistant'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
