### PR TITLE
Add detection logging messages at info level

### DIFF
--- a/java-memory-assistant/detect.go
+++ b/java-memory-assistant/detect.go
@@ -17,7 +17,9 @@
 package java_memory_assistant
 
 import (
+	"github.com/paketo-buildpacks/libpak/bard"
 	"github.com/paketo-buildpacks/libpak/sherpa"
+	"os"
 
 	"github.com/buildpacks/libcnb"
 )
@@ -31,7 +33,9 @@ type Detect struct {
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
 
+	l := bard.NewLogger(os.Stdout)
 	if val := sherpa.ResolveBool("BP_JMA_ENABLED"); !val {
+		l.Logger.Info("SKIPPED: BP_JMA_ENABLED was not set to true")
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 

--- a/java-memory-assistant/detect_test.go
+++ b/java-memory-assistant/detect_test.go
@@ -59,4 +59,13 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			},
 		}))
 	})
+
+	it("BP_JMA_ENABLED was not set", func() {
+		Expect(os.Unsetenv("BP_JMA_ENABLED")).To(Succeed())
+
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+			Pass:  false,
+			Plans: nil,
+		}))
+	})
 }


### PR DESCRIPTION
*Log messages were checked during testing*

```
=== RUN   TestUnit/java-memory-assistant/Detect/BP_JMA_ENABLED_was_not_set
SKIPPED: BP_JMA_ENABLED was not set to true
```


## Summary
This PR adds additional logging when Detect returns false for this buildpack. This is to provide more information about why the detection failed for this buildpack when verbose/debug logging is enabled. 

As of lifecycle v1.16.0, if the detect phase fails as a whole, log messages are printed at info level by default, without the need for the verbose flag.

## Use Cases
A `pack build` command with the `--verbose` flag set will show these log statement if detection fails. If Detect succeeds, the output is not shown unless `--verbose` is set.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
